### PR TITLE
Update atom-zeal.cson

### DIFF
--- a/keymaps/atom-zeal.cson
+++ b/keymaps/atom-zeal.cson
@@ -7,5 +7,5 @@
 
 # For more detailed documentation see
 # https://atom.io/docs/latest/advanced/keymaps
-'.editor:not(.mini)':
+'.atom-text-editor:not(.mini)':
   'ctrl-h': 'atom-zeal:shortcut'


### PR DESCRIPTION
Deprecation cop shows 'atom-text-editor' as selector instead of only 'editor'