### PR TITLE
Limit zeal search according to the language used in atom

### DIFF
--- a/lib/atom-zeal.coffee
+++ b/lib/atom-zeal.coffee
@@ -24,4 +24,6 @@ plugin = module.exports =
     plugin.search(selection)
 
   search: (string) ->
-    exec('zeal --query "' + string + '"')
+    grammar = atom.workspace.getActiveTextEditor().getGrammar()
+    language = grammar.name.toLowerCase()
+    exec('zeal --query "' + language + ':' + string + '"')

--- a/lib/atom-zeal.coffee
+++ b/lib/atom-zeal.coffee
@@ -26,4 +26,17 @@ plugin = module.exports =
   search: (string) ->
     grammar = atom.workspace.getActiveTextEditor().getGrammar()
     language = grammar.name.toLowerCase()
-    exec('zeal --query "' + language + ':' + string + '"')
+
+    # adjust search for some common languages
+    switch language
+        when 'ruby' then language = 'ruby,ruby 2'
+        when 'python' then language = 'python,python 2,python 3'
+        when 'java' then language = 'java se6,java se7,java se8'
+        when 'html' then language = 'html,css'
+        when 'c++' then language = 'c,c++' # + boost?
+
+    if language != 'null grammar'
+        exec('zeal "' + language + ':' + string + '"')
+    else 
+        exec('zeal "' + string + '"')
+    


### PR DESCRIPTION
Limits the search request to zeal by placing "*language name*:" before the search term. 
Additionally I adjusted the restriction for some common languages like Java and C++ due to the multiple versions of the docsets available. If the user has only one version of a language docset installed, the other requested versions are ignored.

Furthermore I removed the depreciated --query parameter which is passed to zeal. 